### PR TITLE
Add Docker support with multi-stage build and GitHub Actions workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.cursor
+.vs
+**/bin
+**/obj
+**/node_modules
+src/Clientside/dist
+src/Clientside/playwright-report
+**/*.user
+*.md

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,28 @@
+name: Build & Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/devex-telemetry:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/devex-telemetry:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: Build frontend
+FROM node:22-alpine AS frontend
+WORKDIR /app
+COPY src/Clientside/package*.json ./src/Clientside/
+WORKDIR /app/src/Clientside
+RUN npm ci --legacy-peer-deps
+COPY src/Clientside/ ./
+RUN npm run build
+
+# Stage 2: Build backend
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS backend
+WORKDIR /app
+COPY src/ ./src/
+COPY --from=frontend /app/src/Agoda.DevExTelemetry.WebApi/wwwroot/ ./src/Agoda.DevExTelemetry.WebApi/wwwroot/
+RUN dotnet restore src/Agoda.DevExTelemetry.sln
+RUN dotnet publish src/Agoda.DevExTelemetry.WebApi/Agoda.DevExTelemetry.WebApi.csproj \
+    -c Release -o /publish --no-restore
+
+# Stage 3: Runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=backend /publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Agoda.DevExTelemetry.WebApi.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - POSTGRES_CONNECTION_STRING=Host=db;Port=5432;Database=devex_telemetry;Username=devex;Password=devex
+    depends_on:
+      - db
+
+  db:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: devex_telemetry
+      POSTGRES_USER: devex
+      POSTGRES_PASSWORD: devex
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

- Add multi-stage Dockerfile (Node.js frontend build → .NET SDK backend build → ASP.NET runtime)
- Add `.dockerignore` to optimize build context
- Add GitHub Actions workflow to build and publish Docker image to Docker Hub on push to `main`
- Add `docker-compose.yml` for running app with PostgreSQL

## Test plan

- [x] `docker build .` succeeds and produces a working image
- [x] Container serves the API at port 8080 (health check at `/api/health` returns 200)
- [x] Container serves the frontend SPA at `/`
- [ ] Configure `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets in GitHub repo settings
- [ ] Verify GitHub Actions workflow runs successfully on merge to `main`

Resolves #6