### PR TITLE
Docs: fix README logo rendering on desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/dx-telemetry-logo-header.svg" alt="DX Telemetry Manager logo" width="720" />
+  <img src="docs/assets/dx-telemetry-logo-header.svg" alt="DX Telemetry Manager logo" width="560" />
 </p>
 
 # DX Telemetry Manager


### PR DESCRIPTION
## Summary
Adjust README header logo width to render better on desktop while keeping mobile appearance clean.

## Change
- Reduce logo width from  to  in README header image tag.

## Scope
- Docs-only change
